### PR TITLE
added no-underscore-dangle exception to eslint config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,6 +20,7 @@
         "computed-property-spacing": [ 2, "always" ],
         "space-infix-ops": [2, {"int32Hint": false}],
         "react/prop-types": [2],
-        "react/require-default-props": [2]
+        "react/require-default-props": [2],
+        "no-underscore-dangle": [ "error", { "allow": [ "_id" ] } ]
       }
 }


### PR DESCRIPTION
edited to eliminate error messages for _id of mongoose